### PR TITLE
Update Team Members List

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,41 @@ Work includes:
 * Node.js and Browser interoperability
 * VM Modules implementation
 
-## Modules Team Members
+## Modules [Team Members](https://github.com/orgs/nodejs/teams/modules/members)
 
-* [@MylesBorins](https://github.com/mylesborins)
+* [Yuta Hiroto](https://github.com/abouthiroppy) @abouthiroppy
+* [Benjamin Gruenbaum](https://github.com/benjamingr) @benjamingr
+* [Ben Newman](https://github.com/benjamn) @benjamn
+* [Bradley Meck](https://github.com/bmeck) @bmeck
+* [Benedikt Meurer](https://github.com/bmeurer) @bmeurer
+* [C J Silverio](https://github.com/ceejbot) @ceejbot
+* [Chris Dickinson](https://github.com/chrisdickinson) @chrisdickinson
+* [Daniel Rosenwasser](https://github.com/DanielRosenwasser) @DanielRosenwasser
+* [Ahmad Abdul-Aziz](https://github.com/devamaz) @devamaz
+* [Gus Caplan](https://github.com/devsnek) @devsnek
+* [Eugene Ostroukhov](https://github.com/eugeneo) @eugeneo
+* [Evan Plaice](https://github.com/evanplaice) @evanplaice
+* [Jeremiah Senkpiel](https://github.com/Fishrock123) @Fishrock123
+* [Gil Tayar](https://github.com/giltayar) @giltayar
+* [Guy Bedford](https://github.com/guybedford) @guybedford
+* [Hassan Sani](https://github.com/inidaname) @inidaname
+* [James M Snell](https://github.com/jasnell) @jasnell
+* [John-David Dalton](https://github.com/jdalton) @jdalton
+* [Jan Olaf Krems](https://github.com/jkrems) @jkrems
+* [Lin Clark](https://github.com/linclark) @linclark
+* [Jordan Harband](https://github.com/ljharb) @ljharb
+* [Wassim Chegham](https://github.com/manekinekko) @manekinekko
+* [Matteo Collina](https://github.com/mcollina) @mcollina
+* [Matt DuLeone](https://github.com/mduleone) @mduleone
+* [Michael Dawson](https://github.com/mhdawson) @mhdawson
+* [Myles Borins](https://github.com/MylesBorins) @MylesBorins
+* [Refael Ackermann](https://github.com/refack) @refack
+* [Rob Palmer](https://github.com/robpalme) @robpalme
+* [Michaël Zasso](https://github.com/targos) @targos
+* [Torgny Bjers](https://github.com/tbjers) @tbjers
+* [Timothy Gu](https://github.com/TimothyGu) @TimothyGu
+* [Andrea Giammarchi](https://github.com/WebReflection) @WebReflection
+* [Wesley Wigham](https://github.com/weswigham) @weswigham
+* [Khaidi Chu](https://github.com/XadillaX) @XadillaX
+* [Yosuke Furukawa](https://github.com/yosuke-furukawa) @yosuke-furukawa
+* [zackschuster](https://github.com/zackschuster) @zackschuster


### PR DESCRIPTION
Using this script on [the following page](https://github.com/orgs/nodejs/teams/modules/members),
helps members page to be sync each update.
```js
// per each page
const members = JSON.parse(localStorage.getItem('members') || '[]');
document.querySelectorAll('a.f4').forEach(a => {
  const name = a.textContent.trim();
  const slug = a.nextElementSibling ?
                a.nextElementSibling.textContent.trim() : name;
  const href = a.href;
  members.push({name, slug, href});
});
localStorage.setItem('members', JSON.stringify(members));

// sort them out after all pages
members.sort((a, b) => {
  const aSlug = a.slug.toLowerCase();
  const bSlug = b.slug.toLowerCase();
  return aSlug < bSlug ? -1 : 1;
});

// generate markdown
console.log(members.map(
  m => `* [${m.name}](${m.href}) @${m.slug}`
).join('\n'));

localStorage.removeItem('members');
```