### PR TITLE
doc: use ncu-team sync to sync member list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,41 +17,50 @@ Work includes:
 
 <!-- ncu-team-sync.team(nodejs/modules) -->
 
-- [@abouthiroppy](https://github.com/abouthiroppy) - Yuta Hiroto
 - [@benjamingr](https://github.com/benjamingr) - Benjamin Gruenbaum
 - [@benjamn](https://github.com/benjamn) - Ben Newman
 - [@bmeck](https://github.com/bmeck) - Bradley Meck
-- [@bmeurer](https://github.com/bmeurer) - Benedikt Meurer
 - [@ceejbot](https://github.com/ceejbot) - C J Silverio
 - [@chrisdickinson](https://github.com/chrisdickinson) - Chris Dickinson
 - [@DanielRosenwasser](https://github.com/DanielRosenwasser) - Daniel Rosenwasser
-- [@devamaz](https://github.com/devamaz) - Ahmad Abdul-Aziz 
+- [@dduleone](https://github.com/dduleone) - Dan DuLeone
+- [@devamaz](https://github.com/devamaz) - Ahmad Abdul-Aziz
 - [@devsnek](https://github.com/devsnek) - Gus Caplan
-- [@eugeneo](https://github.com/eugeneo) - Eugene Ostroukhov
-- [@evanplaice](https://github.com/evanplaice) - Evan Plaice
 - [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
 - [@giltayar](https://github.com/giltayar) - Gil Tayar
 - [@guybedford](https://github.com/guybedford) - Guy Bedford
+- [@iarna](https://github.com/iarna) - Rebecca Turner
 - [@inidaname](https://github.com/inidaname) - Hassan Sani
 - [@jasnell](https://github.com/jasnell) - James M Snell
 - [@jdalton](https://github.com/jdalton) - John-David Dalton
 - [@jkrems](https://github.com/jkrems) - Jan Olaf Krems
+- [@justinfagnani](https://github.com/justinfagnani) - Justin Fagnani
 - [@linclark](https://github.com/linclark) - Lin Clark
 - [@ljharb](https://github.com/ljharb) - Jordan Harband
 - [@manekinekko](https://github.com/manekinekko) - Wassim Chegham
-- [@mcollina](https://github.com/mcollina) - Matteo Collina
 - [@mduleone](https://github.com/mduleone) - Matt DuLeone
 - [@mhdawson](https://github.com/mhdawson) - Michael Dawson
 - [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
-- [@refack](https://github.com/refack) - Refael Ackermann
 - [@robpalme](https://github.com/robpalme) - Rob Palmer
+- [@robwormald](https://github.com/robwormald) - Rob Wormald
 - [@targos](https://github.com/targos) - Michaël Zasso
 - [@tbjers](https://github.com/tbjers) - Torgny Bjers
+- [@tbranyen](https://github.com/tbranyen) - Tim Branyen
+- [@thelarkinn](https://github.com/thelarkinn) - Sean Larkin
 - [@TimothyGu](https://github.com/TimothyGu) - Timothy Gu
 - [@WebReflection](https://github.com/WebReflection) - Andrea Giammarchi
 - [@weswigham](https://github.com/weswigham) - Wesley Wigham
-- [@XadillaX](https://github.com/XadillaX) - Khaidi Chu
-- [@yosuke-furukawa](https://github.com/yosuke-furukawa) - Yosuke Furukawa
-- [@zackschuster](https://github.com/zackschuster) - 
+- [@zackschuster](https://github.com/zackschuster) - Zack Schuster
 
 <!-- ncu-team-sync end -->
+
+## Observers
+
+- [@abouthiroppy](https://github.com/abouthiroppy) - Yuta Hiroto
+- [@bmeurer](https://github.com/bmeurer) - Benedikt Meurer
+- [@eugeneo](https://github.com/eugeneo) - Eugene Ostroukhov
+- [@evanplaice](https://github.com/evanplaice) - Evan Plaice
+- [@mcollina](https://github.com/mcollina) - Matteo Collina
+- [@refack](https://github.com/refack) - Refael Ackermann
+- [@XadillaX](https://github.com/XadillaX) - Khaidi Chu
+- [@yosuke-furukawa](https://github.com/yosuke-furukawa) - Yosuke Furukawa


### PR DESCRIPTION
As was discussed in the last meeting all members that did not fill out
the availability doodle have been moved to observer status.

Observers are not counted toward quorum and do not get to vote

Refs: https://github.com/nodejs/modules/issues/8#issuecomment-364261695
Refs: https://github.com/nodejs/modules/pull/26/