### PR TITLE
governance: s/pull request/issue for new members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ Team Membership is not time-limited. There is no fixed size of the Team.
 
 There is no specific set of requirements or qualifications for Team Membership beyond these rules.
 
-Changes to Team membership should be proposed with a pull-request and labelled `modules-agenda`
+Changes to Team membership should be proposed with an issue and labelled `modules-agenda`
 to be included in the next [team meeting](#team-meetings). Decisions are made via the
 [Consensus Seeking Process](#consensus-seeking-process).
 


### PR DESCRIPTION
Our current process for opening a PR to request membership was
implemented before we started using ncu-sync to keep the membership
list up to date. With this is mind I think it makes more sense
to have new members make a request to join via issue rather than
PR.