### PR TITLE
Create Terminology.md

### DIFF
--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -55,14 +55,18 @@ Normative Terms
   Consumer-defined Disambiguation
 </dt>
 <dd>
+  
   When importing a file into an ESM context, the parse goal of the file is determined by the importing module (the consumer). This is often accomplished via syntax, for example by using only `import` statements for ESM or `require` (or other function) for CommonJS.
+  
 </dd>
 
 <dt id="author-disambiguation">
   Author-defined Disambiguation
 </dt>
 <dd>
+  
   A file or module’s parse goal is included within itself. This is often achieved via a file extension such as `.mjs` or a field in a `package.json` file. Other suggestions have included a `"use module"` directive or unambiguous syntax, such as parsing the file for `import` or `export` statements.
+
 </dd>
 </dl>
   

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -56,13 +56,14 @@ Normative Terms
 </dt>
 <dd>
   When importing a file into an ESM context, the parse goal of the file is determined by the importing module (the consumer). This is often accomplished via syntax, for example by using only `import` statements for ESM or `require` (or other function) for CommonJS.
-</dl>
+</dd>
 
 <dt id="author-disambiguation">
   Author-defined Disambiguation
 </dt>
 <dd>
   A file or module’s parse goal is included within itself. This is often achieved via a file extension such as `.mjs` or a field in a `package.json` file. Other suggestions have included a `"use module"` directive or unambiguous syntax, such as parsing the file for `import` or `export` statements.
+</dd>
 </dl>
   
 Deprecated Terms

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -1,0 +1,64 @@
+Terminology
+============
+
+This document is used to keep track of common terminology related to modules in [Node.js](https://nodejs.org), focusing primarily on ECMAScript Modules as well as other mainstream module formats.
+
+<dl>
+
+Normative Terms
+---------------
+  
+<dt id=agnostic-consumers>
+  Agnostic Consumers
+<dd> 
+
+  The ability for importer modules to be unaware of the imported module type (CJS vs ESM). This implies that the imported module can be migrated from CJS to ESM without impacting the consumer.
+
+  This term alone does not specify in which direction(s) the agnosticism applies.
+
+<dt id=require-interop>
+  Require Interoperability `require(<esm>)`
+<dd>
+  
+  The ability for a module to import an ESM module using the `require(…)` function.
+
+  The module’s namespace is return directly, i.e. it is not wrapped in a promise.
+
+  If it is impossible to load the graph synchronously, it is intended that the call must throw.
+
+<dt id=import-interop>
+  Import Interoperability `import(<cjs>)`
+<dd>
+  
+  The ability for an ESM module to import a CJS module.
+
+  Applies to both static `import … from ` and dynamic `import(…)`.
+
+  This term alone does not specify whether named `exports` are extracted from the CJS exports object.
+
+<dt id="named-exports">
+  Named Exports `exportKeys`
+<dd>
+  
+  The ability for a CJS module to elect to expose properties of its `exports` object as fixed set of named exports for use by ESM consumers, as opposed to having a single `export default` equal to the exports object.
+
+  Some forms of CJS are not amenable, e.g. those that dynamically delete properties of the exports object.
+  
+</dl>
+
+<dl>
+  
+Deprecated Terms
+----------------
+
+<dt id=transparent-interop>
+  Transparent Interoperability
+<dd>
+        
+  An imprecise term that refers to some subset of the following independent capabilities:
+  
+  1. [Agnostic Consumers](#agnostic-consumers) (in one or both directions)
+  2. [Require Interoperability](#require-interop)
+  3. [Import Interoperability](#import-interop) (with or without Named Exports from CJS)
+
+</dl>

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -10,14 +10,16 @@ Normative Terms
   
 <dt id=agnostic-consumers>
   Agnostic Consumers
+</dt>
 <dd> 
-
   The ability for importer modules to be unaware of the imported module type (CJS vs ESM). This implies that the imported module can be migrated from CJS to ESM without impacting the consumer.
 
   This term alone does not specify in which direction(s) the agnosticism applies.
+</dd>
 
 <dt id=require-interop>
-  Require Interoperability `require(<esm>)`
+  Require Interoperability <code>require(<esm>)</code>
+</dt>
 <dd>
   
   The ability for a module to import an ESM module using the `require(…)` function.
@@ -25,9 +27,11 @@ Normative Terms
   The module’s namespace is return directly, i.e. it is not wrapped in a promise.
 
   If it is impossible to load the graph synchronously, it is intended that the call must throw.
+</dd>
 
 <dt id=import-interop>
-  Import Interoperability `import(<cjs>)`
+  Import Interoperability <code>import(<cjs>)</code>
+</dt>
 <dd>
   
   The ability for an ESM module to import a CJS module.
@@ -35,24 +39,28 @@ Normative Terms
   Applies to both static `import … from ` and dynamic `import(…)`.
 
   This term alone does not specify whether named `exports` are extracted from the CJS exports object.
+</dd>
 
 <dt id="named-exports">
-  Named Exports `exportKeys`
+  Named Exports <code>exportKeys</code>
+</dt>
 <dd>
   
   The ability for a CJS module to elect to expose properties of its `exports` object as fixed set of named exports for use by ESM consumers, as opposed to having a single `export default` equal to the exports object.
 
   Some forms of CJS are not amenable, e.g. those that dynamically delete properties of the exports object.
-  
+</dd>
+
 </dl>
 
-<dl>
   
 Deprecated Terms
 ----------------
 
+<dl>
 <dt id=transparent-interop>
   Transparent Interoperability
+</dt>
 <dd>
         
   An imprecise term that refers to some subset of the following independent capabilities:
@@ -60,5 +68,5 @@ Deprecated Terms
   1. [Agnostic Consumers](#agnostic-consumers) (in one or both directions)
   2. [Require Interoperability](#require-interop)
   3. [Import Interoperability](#import-interop) (with or without Named Exports from CJS)
-
+</dd>
 </dl>

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -3,25 +3,32 @@ Terminology
 
 This document is used to keep track of common terminology related to modules in [Node.js](https://nodejs.org), focusing primarily on ECMAScript Modules as well as other mainstream module formats.
 
+<!--
+  dl, dt, dd have a special notation
+    dl always needs to be closed
+    dt always needs to be closed
+    dd only needs to be closed if not followed by dt opener or dl closer
+-->
+
 <dl>
 
 Normative Terms
 ---------------
-  
-<dt id=agnostic-consumers>
+
+<dt id="agnostic-consumers">
   Agnostic Consumers
 </dt>
-<dd> 
+<dd>
   The ability for importer modules to be unaware of the imported module type (CJS vs ESM). This implies that the imported module can be migrated from CJS to ESM without impacting the consumer.
 
   This term alone does not specify in which direction(s) the agnosticism applies.
 </dd>
 
-<dt id=require-interop>
+<dt id="require-interop">
   Require Interoperability <code>require(<esm>)</code>
 </dt>
 <dd>
-  
+
   The ability for a module to import an ESM module using the `require(…)` function.
 
   The module’s namespace is return directly, i.e. it is not wrapped in a promise.
@@ -29,11 +36,11 @@ Normative Terms
   If it is impossible to load the graph synchronously, it is intended that the call must throw.
 </dd>
 
-<dt id=import-interop>
+<dt id="import-interop">
   Import Interoperability <code>import(<cjs>)</code>
 </dt>
 <dd>
-  
+
   The ability for an ESM module to import a CJS module.
 
   Applies to both static `import … from ` and dynamic `import(…)`.
@@ -45,7 +52,7 @@ Normative Terms
   Named Exports <code>exportKeys</code>
 </dt>
 <dd>
-  
+
   The ability for a CJS module to elect to expose properties of its `exports` object as fixed set of named exports for use by ESM consumers, as opposed to having a single `export default` equal to the exports object.
 
   Some forms of CJS are not amenable, e.g. those that dynamically delete properties of the exports object.
@@ -55,21 +62,59 @@ Normative Terms
   Consumer-defined Disambiguation
 </dt>
 <dd>
-  
+
   When importing a file into an ESM context, the parse goal of the file is determined by the importing module (the consumer). This is often accomplished via syntax, for example by using only `import` statements for ESM or `require` (or other function) for CommonJS.
-  
+
 </dd>
 
 <dt id="author-disambiguation">
   Author-defined Disambiguation
 </dt>
 <dd>
-  
+
   A file or module’s parse goal is included within itself. This is often achieved via a file extension such as `.mjs` or a field in a `package.json` file. Other suggestions have included a `"use module"` directive or unambiguous syntax, such as parsing the file for `import` or `export` statements.
 
 </dd>
+
+Stipulative Terms
+-----------------
+
+<dt id="browser-interop">
+  Browser Interop
+</dt>
+<dd>
+
+  The expectation that a module (namely ES modules) can be written once and be used in both Node.js and a "popular browser" that is "reasonably conforming", beyond the implicit requirements of conformance to the behaviours defined by the ECMAScript specificion.
+
+  <dl>
+
+  <dt>browser interoperability</dt>
+  <dd>
+
+  The stipulation for "browser interoperability" of ES modules here extends to the ability to utilize platform-specific features in such a way that would mitigate any potential for irrecoverable runtime exceptions, such as early errors. This stipulation aims to help encourage ES modules adoption rates for both Node.js and "popular browsers".
+
+  It does not exclude interoperability for runtimes where polyfilling can provide a suitable setting, however, that is neither recommended nor considered to determine "browser interoperability". This stipulation aims to help encourage the "responsible use" of tooling as a vital component of the JavaScript ecosystem.
+  </dd>
+
+  <dt>reasonably conforming</dt>
+  <dd>
+
+  The stipulation for "reasonably conforming" here excludes browsers that do not conform to the ECMAScript 2015 specification as well as all module specific features defined in subsequent revisions. It also excludes all forms of drafts, non-normative specifications, and recommended specifications that are "not considered" and/or are intentionally "removed" by "popular browsers".
+  </dd>
+
+  <dt>popular browsers</dt>
+  <dd>
+
+  The term "popular browsers" is intentionally left open to interpretation.
+  </dd>
+
+  </dl>
+</dd>
+
+
 </dl>
-  
+
+
 Deprecated Terms
 ----------------
 
@@ -78,9 +123,9 @@ Deprecated Terms
   Transparent Interoperability
 </dt>
 <dd>
-        
+
   An imprecise term that refers to some subset of the following independent capabilities:
-  
+
   1. [Agnostic Consumers](#agnostic-consumers) (in one or both directions)
   2. [Require Interoperability](#require-interop)
   3. [Import Interoperability](#import-interop) (with or without Named Exports from CJS)

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -51,8 +51,19 @@ Normative Terms
   Some forms of CJS are not amenable, e.g. those that dynamically delete properties of the exports object.
 </dd>
 
+<dt id="consumer-disambiguation">
+  Consumer-defined Disambiguation
+</dt>
+<dd>
+  When importing a file into an ESM context, the parse goal of the file is determined by the importing module (the consumer). This is often accomplished via syntax, for example by using only `import` statements for ESM or `require` (or other function) for CommonJS.
 </dl>
 
+<dt id="author-disambiguation">
+  Author-defined Disambiguation
+</dt>
+<dd>
+  A file or module’s parse goal is included within itself. This is often achieved via a file extension such as `.mjs` or a field in a `package.json` file. Other suggestions have included a `"use module"` directive or unambiguous syntax, such as parsing the file for `import` or `export` statements.
+</dl>
   
 Deprecated Terms
 ----------------


### PR DESCRIPTION
Based on last week's meeting, and based on some testing, this PR would add `doc/Terminology.md` to the main repo. Please note that we will have to use inline HTML tags for since GFM does not provide respective syntaxes for `<dl>`, `<dt>` and `<dd>`. Both AsciiDoc and RST formats were considered since unlike GFM they actually have syntaxes for definitions, but they bring their own complexities and limitations that made them much less ideal for this document.

_Edit (Fishrock123): [**Rendered Markdown**](https://github.com/nodejs/modules/blob/terminology/doc/Terminology.md)_