### PR TITLE
Add format distinction to phase 2

### DIFF
--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -62,6 +62,8 @@ These changes are implemented in https://github.com/nodejs/ecmascript-modules/pu
 * Define semantics for importing a package entry point, e.g. `import _ from 'lodash'`
   - Currently this is only possible via an explicit deep import, e.g. `import _ from 'lodash/index.mjs'`. The idea would be to somehow enable the former syntax.
   - `package.json` `module` field? `main` field?
+  
+* Define semantics for determining when to load sources as CommonJS or ES module for both the top-level main (`node x.js`) and dependency loading.
 
 ## Phase 3
 


### PR DESCRIPTION
I'd like us to add the format distinction question to the Phase 2 process.

It seems important to finally tackle this one and get some movement on solutions here.

This includes any top-level --module flag, as well as internal imports to CommonJS for switching from ESM loading to CJS loading.