### PR TITLE
Add links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Work includes:
 * Node.js and Browser interoperability
 * VM Modules implementation
 
+## Current Efforts
+
+The team is working on a new implementation to potentially replace the `--experimental-modules` implementation in current shipping Node. The new implementation is in progress in the [ecmascript-modules](https://github.com/nodejs/ecmascript-modules) repo, and a road map of its development is [here](./doc/plan-for-new-modules-implementation.md).
+
 ## Features
 
 Based on [these use cases](https://docs.google.com/document/d/10BBsIqdAXB9JR2KUzQGYbCiVugYBnxE4REBakX29yyo/edit) ([#55](https://github.com/nodejs/modules/issues/55)), our implementation aims to support the following features (subject to change):

--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -62,8 +62,11 @@ These changes are implemented in https://github.com/nodejs/ecmascript-modules/pu
 * Define semantics for importing a package entry point, e.g. `import _ from 'lodash'`
   - Currently this is only possible via an explicit deep import, e.g. `import _ from 'lodash/index.mjs'`. The idea would be to somehow enable the former syntax.
   - `package.json` `module` field? `main` field?
+  - Proposal: [“Package Exports” proposal](https://github.com/jkrems/proposal-pkg-exports) for bare module specifier resolution of ESM packages.
+  - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) mentions bare module specifier resolution of CommonJS packages; complements Package Exports proposal.
   
 * Define semantics for determining when to load sources as CommonJS or ES module for both the top-level main (`node x.js`) and dependency loading.
+  - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) covers `import` statements of ESM files; and CommonJS files, package entry point and package deep imports.
 
 ## Phase 3
 


### PR DESCRIPTION
This PR adds links from our new modules implementation plan (with the phases) to the proposals that have been drafted so far; and a link from the main README to the new modules implementation plan and repo.