### PR TITLE
Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ The team is working on a new implementation to potentially replace the `--experi
 
 ### Discussion
 
-The team is using the [node-js.slack.com](https://node-js.slack.com/) channel `#esm` for discussion. To register, please go to [nodeslackers.com](http://www.nodeslackers.com/).
+There are several public places where the modules group has been discussing their work:
+
+- The [issues](https://github.com/nodejs/modules/issues) and [pull requests](https://github.com/nodejs/modules/pulls) on this repo and the [ecmascript-modules](https://github.com/nodejs/ecmascript-modules) repo.
+- The [node-js.slack.com](https://node-js.slack.com/) channel `#esm`. To register, please go to [nodeslackers.com](http://www.nodeslackers.com/).
+- The [#node.js channel on chat.freenode.net](https://webchat.freenode.net/?channels=node.js&uio=d4).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are several public places where the modules group has been discussing thei
 
 - The [issues](https://github.com/nodejs/modules/issues) and [pull requests](https://github.com/nodejs/modules/pulls) on this repo and the [ecmascript-modules](https://github.com/nodejs/ecmascript-modules) repo.
 - The [node-js.slack.com](https://node-js.slack.com/) channel `#esm`. To register, please go to [nodeslackers.com](http://www.nodeslackers.com/).
-- The [#node.js channel on chat.freenode.net](https://webchat.freenode.net/?channels=node.js&uio=d4).
+- The [#node-dev channel on chat.freenode.net](https://webchat.freenode.net/?channels=node-dev&uio=d4).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Work includes:
 
 The team is working on a new implementation to potentially replace the `--experimental-modules` implementation in current shipping Node. The new implementation is in progress in the [ecmascript-modules](https://github.com/nodejs/ecmascript-modules) repo, and a road map of its development is [here](./doc/plan-for-new-modules-implementation.md).
 
+### Discussion
+
+The team is using the [node-js.slack.com](https://node-js.slack.com/) channel `#esm` for discussion. To register, please go to [nodeslackers.com](http://www.nodeslackers.com/).
+
 ## Features
 
 Based on [these use cases](https://docs.google.com/document/d/10BBsIqdAXB9JR2KUzQGYbCiVugYBnxE4REBakX29yyo/edit) ([#55](https://github.com/nodejs/modules/issues/55)), our implementation aims to support the following features (subject to change):


### PR DESCRIPTION
There’s a Slack channel we can use: https://node-js.slack.com/messages/CEVD3CX33/ (node-js.slack.com workspace, `#esm` channel). Everyone is welcome to join. It’s the same Slack workspace that main Node is using, per https://github.com/nodejs/node/blob/master/README.md#support, in the public `#esm` channel.

We’ll need to figure out a way to archive the discussion, but I think this could be a good resource in addition to GitHub comments.