### PR TITLE
--eval, STDIN, and extensionless files

### DIFF
--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -72,7 +72,7 @@ These changes are implemented in https://github.com/nodejs/ecmascript-modules/pu
   - Proposal: ["Dynamic Modules Proposal"](https://github.com/nodejs/dynamic-modules/)
   - We will need to reach consensus on appropriate behavior for [`export * from 'dynamic-module'`](https://github.com/nodejs/dynamic-modules/pull/11). If consensus cannot be reached, then this feature will be deferred to a later phase. The current behavior of throwing may also be reverted at a later time.
 
-* Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN and extensionless files.
+* Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN, and extensionless files.
 
 ## Phase 3
 

--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -72,6 +72,8 @@ These changes are implemented in https://github.com/nodejs/ecmascript-modules/pu
   - Proposal: ["Dynamic Modules Proposal"](https://github.com/nodejs/dynamic-modules/)
   - We will need to reach consensus on appropriate behavior for [`export * from 'dynamic-module'`](https://github.com/nodejs/dynamic-modules/pull/11). If consensus cannot be reached, then this feature will be deferred to a later phase. The current behavior of throwing may also be reverted at a later time.
 
+* Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN and extensionless files.
+
 ## Phase 3
 
 Phase 3 will tentatively focus on extensible loaders and deliver an environment that allows user-land experimentation.


### PR DESCRIPTION
Building off of the [implementation](https://github.com/nodejs/modules/issues/248#issuecomment-455187343) of the [“Package Exports” proposal](https://github.com/jkrems/proposal-pkg-exports) and the [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal), I think we can move on to figuring out how to support ESM input via `--eval`, STDIN and extensionless files.

Anyone interested in forming a small group to hash these out?