### PR TITLE
Revise road map per current status

### DIFF
--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -76,26 +76,28 @@ Phase 2 fleshes out the implementation with enough functionality that it should 
   - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) covers `import` statements of ESM files; and CommonJS files, package entry point and package deep imports.
   - Landed in https://github.com/nodejs/ecmascript-modules/pull/28.
 
-* Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN, and extensionless files.
+* Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN, and extensionless files (both with and without shebang lines).
   - Proposal: [“Entry Points Proposal”](https://github.com/geoffreybooth/node-esm-entry-points-proposal) covers non-file forms of input as well as adding `--type` flag for controlling file-based input.
   - Landed in https://github.com/nodejs/ecmascript-modules/pull/32.
 
-* Dual CommonJS/ESM packages: Support packages that can both be `require`d as CommonJS and `import`ed as ESM, with separate entry points for each.
-  - Proposal: https://github.com/nodejs/modules/issues/273.
-  - PR: https://github.com/nodejs/ecmascript-modules/pull/41.
+* A loaders solution that supports all items in the [features list in our README](https://github.com/nodejs/modules/#features).
+  - Should loaders be per package, per application or either?
+  - Will land in Phase 2 only if an implementation without major problems (e.g. memory leaks) can be completed in time. If the problems can be isolated behind a flag, we could upstream a buggy implementation and fix and unflag it after unflagging.
+
 
 ## Phase 3: Path to Stability: Removing `--experimental-modules` Flag
 
-Phase 3 improves user experience and extends the MVP. At the end of this phase, the `--experimental-modules` flag is dropped.
+Phase 3 improves user experience and extends the MVP. Phase 3 is malleable based on how things proceed while working on this phase. At the end of this phase, the `--experimental-modules` flag is dropped.
 
 ### UX Improvements
+
+* Dual CommonJS/ESM packages: Either support packages that can both be `require`d as CommonJS and `import`ed as ESM; or decide to specifically not support dual CommonJS/ESM packages.
+  - Proposal: https://github.com/nodejs/modules/issues/273.
+  - PR: https://github.com/nodejs/ecmascript-modules/pull/41.
 
 * Better mechanism for creating `require` function.
   - See [https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676](https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676).
   - `import 'nodejs:require'`? `import.meta.require`? Or only `createRequireFromPath`?
-
-* A loaders solution that supports all items in the [features list in our README](https://github.com/nodejs/modules/#features).
-  - Should loaders be per package, per application or either?
 
 * Map the paths within modules, providing similar functionality as the browser’s [import maps proposal](https://github.com/WICG/import-maps#packages-via-trailing-slashes).
   - Proposal: [“Package Exports Proposal”](https://github.com/jkrems/proposal-pkg-exports).

--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -68,6 +68,8 @@ The “minimal kernel” consists of features that the @nodejs/modules group hav
 
 Phase 2 fleshes out the implementation with enough functionality that it should be useful to average users as a minimum viable product. At the completion of Phase 2, the old `--experimental-modules` implementation is replaced with this new one (still behind the `--experimental-modules` flag).
 
+### Core Functionality
+
 * Define semantics for importing a package entry point, e.g. `import _ from 'lodash'`
   - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) covers bare module specifier resolution of CommonJS packages.
   - Landed in https://github.com/nodejs/ecmascript-modules/pull/28.
@@ -82,7 +84,12 @@ Phase 2 fleshes out the implementation with enough functionality that it should 
 
 * A loaders solution that supports all items in the [features list in our README](https://github.com/nodejs/modules/#features).
   - Should loaders be per package, per application or either?
-  - Will land in Phase 2 only if an implementation without major problems (e.g. memory leaks) can be completed in time. If the problems can be isolated behind a flag, we could upstream a buggy implementation and fix and unflag it after unflagging.
+  - Will land in Phase 2 only if an implementation without major problems (e.g. memory leaks) can be completed in time. If the problems can be isolated behind a flag specific to loaders, we could upstream a buggy implementation and unflag it after its bugs are fixed.
+
+### Needs Consensus
+
+* Add, or decide not to support, file extension and directory index searching in ESM.
+  - See https://github.com/nodejs/modules/issues/268.
 
 
 ## Phase 3: Path to Stability: Removing `--experimental-modules` Flag
@@ -110,6 +117,3 @@ Phase 3 improves user experience and extends the MVP. Phase 3 is malleable based
 * Finalize support for (or removal of) `import` of CommonJS files and packages.
   - See https://github.com/nodejs/modules/issues/264.
   - Defaults only or named exports? Behind a flag or not?
-
-* File extension/directory index searching in ESM.
-  - See https://github.com/nodejs/modules/issues/268.

--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -1,6 +1,19 @@
 # Plan for New Modules Implementation
 
-This document outlines the plan for building a new implementation to support ECMAScript modules in Node.js. The general idea is to start with a “minimal kernel” as Phase 1, which consists of features that the @nodejs/modules group have agreed will be necessary for all potential iterations of our ESM implementation. Phase 1 does _not_ include features that preclude other potential features or implementation approaches; and Phase 1 also does not include some features that should naturally be built in a later phase of development, for example because those features depend on features planned for Phase 1. The minimal kernel/phase 1 is _not_ intended to be merged into Node core or released; it is only a starting point for gradually building layers of consensus.
+This document outlines the plan for building a new implementation to support ECMAScript modules in Node.js. The effort is split up into phases:
+
+* **Phase 0** branches off of current Node but removes much of the Node 8.5.0+ `--experimental-modules` implementation so that a new implementation could be built in its place.
+
+* **Phase 1** adds the “minimal kernel,” features that the modules working group felt would likely appear in any potential new ES modules implementation.
+
+* **Phase 2** fleshes out the implementation with enough functionality that it should be useful to average users as a minimum viable product.
+  - At the completion of Phase 2, the old `--experimental-modules` implementation is replaced with this new one (still behind the `--experimental-modules` flag). The goal is to “upstream” the new implementation with the release of Node 12, in April 2019.
+
+* **Phase 3** improves user experience and extends the MVP.
+
+  - At the completion of Phase 3, the new implementation’s experimental flag is dropped. The goal is to “release” (drop the `--experimental-modules` flag) by when Node 12 starts LTS in October 2019.
+
+The effort is currently in **Phase 2**.
 
 At every phase, the following standards must be maintained:
 
@@ -10,29 +23,9 @@ At every phase, the following standards must be maintained:
 
 See also the [features list in the README](https://github.com/nodejs/modules#features).
 
-## Phase 1: The Minimal Kernel
+## Phase 0: Start Fresh
 
-These features will be part of the first phase of development:
-
-* `module.createRequireFromPath` ([nodejs/node#19360](https://github.com/nodejs/node/pull/19360)) is the only way to import CommonJS into an ES module, for now.
-  - `import.meta.require` fails at runtime as opposed to import time. This is not desireable to all committee members
-  - Hold off on `import` statements for CommonJS until more progress is made on the dynamic modules spec.
-  - landed in https://github.com/nodejs/node/commit/246f6332e5a5f395d1e39a3594ee5d6fe869d622
-
-* `import` statements will only support files with an `.mjs` extension, and will import only ES modules, for now.
-  - In a later phase, the intention is to move forward with format databases to map extensions and support multiple use cases.
-  - No JSON or native modules; `createRequireFromPath` can be used to get these.
-
-* `import.meta.url`.
-  - Already in the existing implementation.
-
-* Dynamic `import()`.
-  - Already in the existing implementation.
-
-* Support for built-in modules with named exports
-  - Already in the existing implementation
-
-### How will we get from where we are to Phase 1
+From current shipping Node, the following changes were made to strip out most of the Node 8.5.0+ `--experimental-modules` implementation so that a new implementation could be built in its place:
 
 * Remove support in the `import` statement of formats other than ESM:
   - No CommonJS.
@@ -48,42 +41,73 @@ These features will be part of the first phase of development:
 
 * Remove current Loader implementation
 
-These changes are implemented in https://github.com/nodejs/ecmascript-modules/pull/6
+These changes were implemented in https://github.com/nodejs/ecmascript-modules/pull/6.
 
-## Phase 2
+## Phase 1: The Minimal Kernel
 
-* Explore design space for virtual module from source
-  - Potential implementation in: https://github.com/nodejs/ecmascript-modules/pull/8.
+The “minimal kernel” consists of features that the @nodejs/modules group have agreed will be necessary for all potential iterations of our ESM implementation. Phase 1 does _not_ include features that preclude other potential features or implementation approaches; and Phase 1 also does not include some features that should naturally be built in a later phase of development, for example because those features depend on features planned for Phase 1.
 
-* Improve CommonJS interoperability.
-  - Refine `createRequireFromPath`.
-  - See [https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676](https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676).
+* `module.createRequireFromPath` ([nodejs/node#19360](https://github.com/nodejs/node/pull/19360)) is the only way to import CommonJS into an ES module, for now.
+  - `import.meta.require` fails at runtime as opposed to import time. This is not desireable to all committee members.
+  - Hold off on `import` statements for CommonJS until more progress is made on the dynamic modules spec.
+  - Landed in core in https://github.com/nodejs/node/commit/246f6332e5a5f395d1e39a3594ee5d6fe869d622
+
+* `import` statements will only support files with an `.mjs` extension, and will import only ES modules, for now.
+  - No JSON or native modules; `createRequireFromPath` can be used to get these.
+
+* `import.meta.url`.
+  - Already in the existing implementation.
+
+* Dynamic `import()`.
+  - Already in the existing implementation.
+
+* Support for built-in modules with named exports
+  - Already in the existing implementation.
+
+## Phase 2: Minimum Viable Product: Required to Upstream
+
+Phase 2 fleshes out the implementation with enough functionality that it should be useful to average users as a minimum viable product. At the completion of Phase 2, the old `--experimental-modules` implementation is replaced with this new one (still behind the `--experimental-modules` flag).
 
 * Define semantics for importing a package entry point, e.g. `import _ from 'lodash'`
-  - Currently this is only possible via an explicit deep import, e.g. `import _ from 'lodash/index.mjs'`. The idea would be to somehow enable the former syntax.
-  - `package.json` `module` field? `main` field?
-  - Proposal: [“Package Exports” proposal](https://github.com/jkrems/proposal-pkg-exports) for bare module specifier resolution of ESM packages.
-  - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) mentions bare module specifier resolution of CommonJS packages; complements Package Exports proposal.
+  - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) covers bare module specifier resolution of CommonJS packages.
+  - Landed in https://github.com/nodejs/ecmascript-modules/pull/28.
 
 * Define semantics for determining when to load sources as CommonJS or ES module for both the top-level main (`node x.js`) and dependency loading.
   - Proposal: [“File Specifier Resolution” proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) covers `import` statements of ESM files; and CommonJS files, package entry point and package deep imports.
-
-* Implement specification changes related to dynamic module records
-  - Proposal: ["Dynamic Modules Proposal"](https://github.com/nodejs/dynamic-modules/)
-  - We will need to reach consensus on appropriate behavior for [`export * from 'dynamic-module'`](https://github.com/nodejs/dynamic-modules/pull/11). If consensus cannot be reached, then this feature will be deferred to a later phase. The current behavior of throwing may also be reverted at a later time.
+  - Landed in https://github.com/nodejs/ecmascript-modules/pull/28.
 
 * Define semantics for enabling ESM treatment of source code loaded via `--eval`, STDIN, and extensionless files.
+  - Proposal: [“Entry Points Proposal”](https://github.com/geoffreybooth/node-esm-entry-points-proposal) covers non-file forms of input as well as adding `--type` flag for controlling file-based input.
+  - Landed in https://github.com/nodejs/ecmascript-modules/pull/32.
 
-## Phase 3
+* Dual CommonJS/ESM packages: Support packages that can both be `require`d as CommonJS and `import`ed as ESM, with separate entry points for each.
+  - Proposal: https://github.com/nodejs/modules/issues/273.
+  - PR: https://github.com/nodejs/ecmascript-modules/pull/41.
 
-Phase 3 will tentatively focus on extensible loaders and deliver an environment that allows user-land experimentation.
+## Phase 3: Path to Stability: Removing `--experimental-modules` Flag
 
-We should try to find a loaders solution that supports all items in the [features list in our README](https://github.com/nodejs/modules/#features).
+Phase 3 improves user experience and extends the MVP. At the end of this phase, the `--experimental-modules` flag is dropped.
 
-## Phase 4
+### UX Improvements
 
-Phase 4 will include addressing user feedback gathered from the experimentation enabled by Phase 3 and focus on a holistic and complete experience of ESM in Node.js.
+* Better mechanism for creating `require` function.
+  - See [https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676](https://gist.github.com/SMotaal/e73c12bd801d78a3108fa30ecd303676).
+  - `import 'nodejs:require'`? `import.meta.require`? Or only `createRequireFromPath`?
 
-## Future Phases
+* A loaders solution that supports all items in the [features list in our README](https://github.com/nodejs/modules/#features).
+  - Should loaders be per package, per application or either?
 
-TBD.
+* Map the paths within modules, providing similar functionality as the browser’s [import maps proposal](https://github.com/WICG/import-maps#packages-via-trailing-slashes).
+  - Proposal: [“Package Exports Proposal”](https://github.com/jkrems/proposal-pkg-exports).
+
+* Automatic entry point module type detection.
+  - Proposal: [“Entry Points Proposal”](https://github.com/geoffreybooth/node-esm-entry-points-proposal) includes `--type=auto` flag for running `.js` files in either ESM or CommonJS based on which module system is detected.
+
+### Needs Consensus
+
+* Finalize support for (or removal of) `import` of CommonJS files and packages.
+  - See https://github.com/nodejs/modules/issues/264.
+  - Defaults only or named exports? Behind a flag or not?
+
+* File extension/directory index searching in ESM.
+  - See https://github.com/nodejs/modules/issues/268.


### PR DESCRIPTION
Readable version: https://github.com/GeoffreyBooth/modules/blob/update-roadmap/doc/plan-for-new-modules-implementation.md. The diff is a mess so you might want to just read that side-by-side with the [current version](https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md).

@MylesBorins and I worked together to update our new implementation’s plan per [the Google doc where the team has noted our current status](https://docs.google.com/document/d/1DSWrdV1fzXvlOdTZ5MngDX7v6CU4ZUheJ7ysOZ2uK0w/edit?ts=5c63dc98). In particular:

- The “How will we get from where we are to Phase 1” section has been moved to a new Phase 0, to reflect that it’s already done and was a precursor to our Phase 1.
- The end of Phase 2 corresponds with replacing the existing `--experimental-modules` with our new implementation, while the end of Phase 3 corresponds with dropping the `--experimental-modules` flag. There is no longer an empty Phase 4.
- Phase 2 includes the features listed under the “Requirements to replace upstream implementation” section in the [Google doc](https://docs.google.com/document/d/1DSWrdV1fzXvlOdTZ5MngDX7v6CU4ZUheJ7ysOZ2uK0w/edit?ts=5c63dc98). Previous Phase 2 features that weren’t in that section of the Google Doc have been moved into Phase 3.
- Phase 3’s features are split into two groups: UX improvements, and things that need consensus.

This is just a rewrite of the document to _reflect_ the plan as it stands in the Google doc. This PR isn’t intended to _change_ the plan. If the group decides to move features between phases, that can certainly happen, but we didn’t want to include plan changes along with reformatting this document.