### PR TITLE
Table source type detection

### DIFF
--- a/doc/plan-for-new-modules-implementation.md
+++ b/doc/plan-for-new-modules-implementation.md
@@ -139,7 +139,7 @@ Phase 3 improves user experience and extends the MVP. Phase 3 is malleable based
 * Limited module type detection.
   - PR: https://github.com/nodejs/ecmascript-modules/pull/69.
   - Upstream PR: https://github.com/nodejs/node/pull/27808.
-  - **Status**: Upstream PR submitted.
+  - **Tabled**. The group’s current thinking is to encourage explicit source type definition via file extension or the `"type"` field. Source type detection via parsing source code is not 100% accurate and should therefore be left to userland where users can choose to accept its risks.
 
 * Provide a way to make ESM the default instead of CommonJS.
   - Discussion: https://github.com/nodejs/modules/issues/318.


### PR DESCRIPTION
So eight months ago I opened https://github.com/nodejs/node/pull/27808 to add a utility method to Node core for detecting if JavaScript source code contained ES module syntax. That PR is still open and it’s not looking likely that it will be merged anytime soon, so I’m thinking of closing it. I might release the code as a standalone NPM package.

The PR’s `containsModuleSyntax` method wasn’t all that useful on its own, and wasn’t used by Node core; it was created to be a dependency for potential Node core features like `--input-type=auto`. Are will still planning on implementing `--input-type=auto`, or any other feature that might rely on `containsModuleSyntax`?

If not, I can close the PR and mark this roadmap item as done/tabled, unless anyone has any objections or reasons we might want source detection in the future.