### PR TITLE
Add Doron Tsur as an Observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ Work includes:
 - [@xtuc](https://github.com/xtuc) - Sven Sauleau
 - [@yosuke-furukawa](https://github.com/yosuke-furukawa) - Yosuke Furukawa
 - [@zackschuster](https://github.com/zackschuster) - Zack Schuster
+- [@qballer](https://github.com/qballer) - Doron Tsur
 
 <!-- ncu-team-sync end -->

--- a/doc/meetings/2020-07-29.md
+++ b/doc/meetings/2020-07-29.md
@@ -15,7 +15,6 @@
 * Myles Borins (@MylesBorins)
 * Bradley Farias (@bmeck)
 * Jordan Harband (@ljharb)
-* Wesley Wigham (@weswigham)
 
 ## Agenda
 


### PR DESCRIPTION
I would like to participate in the module group meeting as an observer. 
I'm interested in the ESM specification and in the emerging import map standard.
