### PR TITLE
Add Doron Tsur as observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Work includes:
 - [@manekinekko](https://github.com/manekinekko) - Wassim Chegham
 - [@mcollina](https://github.com/mcollina) - Matteo Collina
 - [@mhdawson](https://github.com/mhdawson) - Michael Dawson
+- [@qballer](https://github.com/qballer) - Doron Tsur
 - [@rubys](https://github.com/rubys) - Sam Ruby
 - [@ryzokuken](https://github.com/ryzokuken) - Ujjwal Sharma
 - [@sendilkumarn](https://github.com/sendilkumarn) - Sendil Kumar N


### PR DESCRIPTION
I would like to participate in the module group meetings.
I'm interested in the ESM specification and the emerging import map standard. 