### PR TITLE
fix: add members missed by ncu-team to team list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The current team exists as subject matter experts to consult regarding the Node.
 
 - [@bmeck](https://github.com/bmeck) - Bradley Farias
 - [@DanielRosenwasser](https://github.com/DanielRosenwasser) - Daniel Rosenwasser
+- [@DerekNonGeneric](https://github.com/DerekNonGeneric) - Derek Lewis
 - [@devsnek](https://github.com/devsnek) - devsnek
 - [@GeoffreyBooth](https://github.com/GeoffreyBooth) - Geoffrey Booth
 - [@giltayar](https://github.com/giltayar) - Gil Tayar


### PR DESCRIPTION
This PR adds members missed by the `ncu-team` tool to the team list.